### PR TITLE
CA Certificate Update Patch

### DIFF
--- a/docker/DockerFile.deepstream.ros2.eloquent
+++ b/docker/DockerFile.deepstream.ros2.eloquent
@@ -37,13 +37,15 @@ ENV LANG=en_US.UTF-8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
           git \
-		cmake \
-		build-essential \
-		curl \
-		wget \ 
-		gnupg2 \
-		lsb-release \
-    && rm -rf /var/lib/apt/lists/*
+          cmake \
+          build-essential \
+          curl \
+          wget \
+          gnupg2 \
+          lsb-release \
+          ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && \
     apt-get install -y libqt5svg5 && \

--- a/docker/DockerFile.deepstream.ros2.foxy
+++ b/docker/DockerFile.deepstream.ros2.foxy
@@ -37,11 +37,14 @@ ENV LANG=en_US.UTF-8
 # add the ROS deb repo to the apt sources list
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-		curl \
-		wget \
-		gnupg2 \
-		lsb-release \
-    && rm -rf /var/lib/apt/lists/*
+          curl \
+          wget \
+          gnupg2 \
+          lsb-release \
+          ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null

--- a/docker/DockerFile.l4tbase.ros.noetic
+++ b/docker/DockerFile.l4tbase.ros.noetic
@@ -35,13 +35,15 @@ WORKDIR /workspace
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
           git \
-		cmake \
-		build-essential \
-		curl \
-		wget \
-		gnupg2 \
-		lsb-release \
-    && rm -rf /var/lib/apt/lists/*
+          cmake \
+          build-essential \
+          curl \
+          wget \
+          gnupg2 \
+          lsb-release \
+          ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654

--- a/docker/DockerFile.l4tbase.ros2.eloquent
+++ b/docker/DockerFile.l4tbase.ros2.eloquent
@@ -34,17 +34,18 @@ RUN locale-gen en_US en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.
 ENV LANG=en_US.UTF-8
 
 # add the ROS deb repo to the apt sources list
-RUN apt-get update
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
           git \
-		cmake \
-		build-essential \
-		curl \
-		wget \ 
-		gnupg2 \
-		lsb-release \
-    && rm -rf /var/lib/apt/lists/*
+          cmake \
+          build-essential \
+          curl \
+          wget \
+          gnupg2 \
+          lsb-release \
+          ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null

--- a/docker/DockerFile.l4tbase.ros2.foxy
+++ b/docker/DockerFile.l4tbase.ros2.foxy
@@ -37,11 +37,14 @@ ENV LANG=en_US.UTF-8
 # add the ROS deb repo to the apt sources list
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-		curl \
-		wget \
-		gnupg2 \
-		lsb-release \
-    && rm -rf /var/lib/apt/lists/*
+          curl \
+          wget \
+          gnupg2 \
+          lsb-release \
+          ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null


### PR DESCRIPTION
Added Dockerfile instructions to update ca certificates. 

At the moment they are broken without updating certificates. 

Error: 
```bash
Step 12/52 : RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 ---> Running in 10b0a2963c2c
curl: (77) error setting certificate verify locations:
  CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
The command '/bin/sh -c curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg' returned a non-zero code: 77
```